### PR TITLE
Updating z_importkey parameters

### DIFF
--- a/doc/source/rtd_pages/rtd_docs/payment_api.rst
+++ b/doc/source/rtd_pages/rtd_docs/payment_api.rst
@@ -184,13 +184,14 @@ Key Management
 |                       |                        |                                                                                   |
 +-----------------------+------------------------+-----------------------------------------------------------------------------------+
 |.. _z_importkey:       | | zkey                 | | Wallet must be unlocked. Add a zkey as returned by                              |
-|                       | | [rescan=true]        | | z_exportkey to a node's wallet. The key should be                               |
-|z_importkey            |                        | | formatted using Base58Check as described in the Zcash                           |
-|                       |                        | | protocol spec. Set rescan to true (the default) to rescan                       |
-|                       |                        | | the entire local block database  for transactions affecting                     |
-|                       |                        | | any address or pubkey script in the wallet (including                           |
-|                       |                        | | transactions affecting the newly-added address for this                         |
-|                       |                        | | spending key).                                                                  |
+|                       | | [rescan=             | | z_exportkey to a node's wallet. The key should be                               |
+|z_importkey            | | whenkeyisnew]        | | formatted using Base58Check as described in the Zcash                           |
+|                       | | [startHeight=0]      | | protocol spec. Rescan can be "yes", "no" or the default                         |
+|                       |                        | | "whenkeyisnew" to rescan for transactions affecting any                         |
+|                       |                        | | address or pubkey script in the wallet (including transactions                  |
+|                       |                        | | affecting the newly-added address for this spending key).                       |
+|                       |                        | | The startHeight parameter sets the block height to start                        |
+|                       |                        | | the rescan from (default is 0).                                                 |
 |                       |                        |                                                                                   |
 |                       |                        +-----------------------------------------------------------------------------------+
 |                       |                        |``./zcash-cli z_importkey AKWUAkypwQjhZ6LLNa...``                                  |


### PR DESCRIPTION
Updated to match the output of the CLI:

```
zcash-cli help z_importkey
z_importkey "zkey" ( rescan startHeight )

Adds a zkey (as returned by z_exportkey) to your wallet.

Arguments:
1. "zkey"             (string, required) The zkey (see z_exportkey)
2. rescan             (string, optional, default="whenkeyisnew") Rescan the wallet for transactions - can be "yes", "no" or "whenkeyisnew"
3. startHeight        (numeric, optional, default=0) Block height to start rescan from
```