### PR TITLE
Add Transifex Live script

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -164,3 +164,7 @@ texinfo_documents = [
      author, 'ZCashDocumentation', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+html_context = {
+    'script_files': ['_static/js/transifex-api.js', '//cdn.transifex.com/live.js']
+}

--- a/doc/source/nstatic/js/transifex-api.js
+++ b/doc/source/nstatic/js/transifex-api.js
@@ -1,0 +1,1 @@
+window.liveSettings={api_key:"1a59b1edf56d413184e53c25d2eb9183"};


### PR DESCRIPTION
The API key is unique per domain corresponding to settings in the Transifex project. This is for the production domain (https://zcash.readthedocs.io).

Transifex docs regarding this Live integration: https://docs.transifex.com/live/installing-the-javascript-snippet